### PR TITLE
reset peer instead of close

### DIFF
--- a/os/net/app-layer/coap/coap-uip.c
+++ b/os/net/app-layer/coap/coap-uip.c
@@ -321,7 +321,7 @@ coap_endpoint_disconnect(coap_endpoint_t *ep)
 {
 #ifdef WITH_DTLS
   if(ep && ep->secure && dtls_context) {
-    dtls_close(dtls_context, ep);
+    dtls_reset_peer(dtls_context, ep);
   }
 #endif /* WITH_DTLS */
 }


### PR DESCRIPTION
When you call close it will send a close request to the peer,
if the peer does not respond then it stays in the closing state
and you are unable to open a new connection or create a new
peer. By calling reset peer we still send a close request but we also
clear the peer.