### PR TITLE
coap-uip dtls reset peer instead of close

### DIFF
--- a/os/net/app-layer/coap/coap-uip.c
+++ b/os/net/app-layer/coap/coap-uip.c
@@ -320,8 +320,12 @@ void
 coap_endpoint_disconnect(coap_endpoint_t *ep)
 {
 #ifdef WITH_DTLS
+  dtls_peer_t *peer;
   if(ep && ep->secure && dtls_context) {
-    dtls_close(dtls_context, ep);
+    peer = dtls_get_peer(dtls_context, ep);
+    if(peer != NULL) {
+      dtls_reset_peer(dtls_context, peer);
+    }
   }
 #endif /* WITH_DTLS */
 }


### PR DESCRIPTION
When you call close it will send a close request to the peer,
if the peer does not respond then it stays in the closing state
and you are unable to open a new connection or create a new
peer. By calling reset peer we still send a close request but we also
clear the peer.